### PR TITLE
#29: only add chrome autofill styles if not added

### DIFF
--- a/src/lib/chromeAutofill.ts
+++ b/src/lib/chromeAutofill.ts
@@ -15,10 +15,13 @@ input:-webkit-autofill {
 `;
 
 function startAnimationWhenAutofilled() {
-  const style = document.createElement("style");
-  style.setAttribute("type", "text/css");
-  style.appendChild(document.createTextNode(css));
-  document.head.appendChild(style);
+  if (document.getElementById("svelte-use-form-chrome-autofill-styles") === null) {
+    const style = document.createElement("style");
+    style.setAttribute("id", "svelte-use-form-chrome-autofill-styles")
+    style.setAttribute("type", "text/css");
+    style.appendChild(document.createTextNode(css));
+    document.head.appendChild(style);
+  }
 }
 
 export function handleChromeAutofill(


### PR DESCRIPTION
This quick fix will ensure the chrome autofill styles will get populated only once.