### PR TITLE
Add pattern validator to validators

### DIFF
--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -50,3 +50,19 @@ export function number(value: string): null | ValidationErrors {
   }
   return { number: {} };
 }
+
+
+
+
+function isString(x) {
+  return Object.prototype.toString.call(x) === "[object String]"
+} 
+
+export function pattern(regexp: string | RegExp){
+  const r = isString(regexp)? new RegExp(regexp) : regexp
+  return (value:string): null | ValidationErrors => {
+    return  (r as RegExp).test(value)
+      ? null
+      : { pattern: "Pattern error" };
+  }
+} 


### PR DESCRIPTION
I created this validator as a generica pattern validator.

Usage is as follows (example of a pattern regexp having at least 8 chars/numbers and a special char):

<input
      type="password"
      name="password"
      use:validators={[
        required,
        pattern(/^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,}$/)
      ]} />

