### PR TITLE
24 Improve Typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,37 +5,29 @@
   </h1>
 
 A svelte form library that is easy to use and has no boilerplate. It helps you control and validate forms and their fields and check on the state of them.
+
 ```bash
 npm i -D svelte-use-form
 ```
+
 <a href="https://npmjs.com/package/svelte-use-form">![GitHub package.json version](https://img.shields.io/github/package-json/v/noahsalvi/svelte-use-form?style=for-the-badge)</a>
 <a href="https://npmjs.com/package/svelte-use-form">![npm](https://img.shields.io/npm/dw/svelte-use-form?style=for-the-badge)</a>
 
-
-
-
-  
-
-#### Features:
+**Features:**
 
 - Supports: Inputs, TextAreas, Selects, Radio Buttons, Checkboxes...
 - Uses single object to represent the state, instead of splitting it up (errors, values, controls...)
 - Requires no special binding on the Form Input Elements, only the name attribute
 - OOTB validators and custom validator support
 - No requirement to use custom components
-- Dynamic Inputs => Show / Hide Inputs at runtime.
+- Works with dynamic inputs => Show / Hide Inputs at runtime.
 
-## Usage
+# Usage
 
 It's pretty self-explanatory, just check out the examples below 😉<br>
 Just make sure to prefix the form with `$`, when accessing its state.
 
-#### REPLs:
-
-- [Registration](https://svelte.dev/repl/a6665267d7d0435ebc7921a250552a25?version=3.34.0)
-- [Testing the limits](https://svelte.dev/repl/d4fc021f688d4ad0b3ceb9a1c44c9be9?version=3.34.0)
-
-### Minimal Example [REPL](https://svelte.dev/repl/faf5a9ab763640ed830028c970421f72?version=3.35.0)
+**Minimal Example** [REPL](https://svelte.dev/repl/faf5a9ab763640ed830028c970421f72?version=3.35.0)
 
 ```svelte
 <script>
@@ -54,7 +46,7 @@ Just make sure to prefix the form with `$`, when accessing its state.
 </form>
 ```
 
-or you can also print the error message like this:
+or you could also print the error message like this:
 
 ```svelte
 ...
@@ -63,7 +55,7 @@ or you can also print the error message like this:
   {/if}
 ```
 
-### Login Example (Styling omitted) [REPL](https://svelte.dev/repl/ca967b45a5aa47b2bb2f9118eb79eefe?version=3)
+**Login Example (Styling omitted)** [REPL](https://svelte.dev/repl/ca967b45a5aa47b2bb2f9118eb79eefe?version=3)
 
 ```svelte
 <script>
@@ -88,93 +80,123 @@ or you can also print the error message like this:
 </form>
 ```
 
-## API
+## More Examples
 
-### const form = useForm(properties)
+**REPLs:**
+
+- [Registration](https://svelte.dev/repl/a6665267d7d0435ebc7921a250552a25?version=3.34.0)
+- [Testing the limits](https://svelte.dev/repl/d4fc021f688d4ad0b3ceb9a1c44c9be9?version=3.34.0)
+
+# API
+
+## `const form = useForm(FormProperties)`
 
 useForm() returns a svelte `store` (Observable) that is also an `action`. (That's what I call [svelte](https://www.dictionary.com/browse/svelte) 😆)<br>
 
-#### properties
+### FormProperties
 
 ```typescript
-interface FormProperties {
-  [control: string]: {
+export type FormProperties = {
+  [key: string]: {
     /** Initial value of the form control */
     initial?: string;
     /** The validators that will be checked when the input changes */
     validators?: Validator[];
     /**
-     * The map through which validation errors will be passed.
-     *
+     * The map through which validation errors will be mapped.
      * You can either pass a string or a function returning a new error value
+     *
+     * **Think of it as a translation map. 😆**
      */
     errorMap?: ErrorMap;
   };
-}
+};
 ```
 
-#### form
+### form
 
-Contains an `action` that can be used on a form. It binds the form state to the form element.
+Contains an `action` that can be used on a `<form>`. It binds the form state to the form element.
 
-#### $form
+### $form
 
 Subscribe to the form with `$` prefix to access the state of the form. It returns a `Form` instance.
 
-### Form
+### `Form`
+
+Remark: The "Form" is an union of multiple types and its self.
 
 ```typescript
 class Form {
-  [formControlName: string]: FormControl;
-  get valid(): boolean;
-  get touched(): boolean;
-  get values(): {
+  valid: boolean;
+  touched: boolean;
+  values: {
     [formControlName: string]: string;
   };
+  reset(): void;
+  [formControlName: string]: FormControl;
 }
 ```
 
-Every input in the form will be accessible through $form directly. e.g. `<input name="email" />` === $form.email
+Every form control in the form will be accessible through $form directly via the name attribute. e.g. `<input name="email" />` === $form.email
 
-### FormControl
+## `FormControl`
 
-```typescript
-/** A FormControl represents the state of a form member like (input, textarea...) */
+````typescript
+/** A FormControl represents the state of a {@link FormControlElement} like (input, textarea...) */
 export declare class FormControl {
   validators: Validator[];
   /**
-   * Returns an object containing possible ValidationErrors
-   * ### Example (All validators are throwing an error)
+   * Returns an object containing possible validation errors
+   * @example
+   * (All validators are throwing an error)
    * `{ required: true, minLength: 4, maxLength: 20 }`
-   * ### Example 2 (Only required is not valid)
+   * (Only required is invalid)
    * `{ required: true }`
    */
-  errors: {
-    [errorName: string]: ValidationErrors;
-  };
+  errors: ValidationErrors;
   /**
    * Contains a map of values, that will be shown
    * in place of the original validation error.
    */
-  errorMap: ErrorMap = {};
-  /** If the FormControl passed all given validators. */
+  errorMap: ErrorMap;
+  /**
+   * The DOM elements representing this control
+   */
+  elements: FormControlElement[];
+  /** Does the FormControl pass all given validators? */
   valid: boolean;
   /**
    * If the FormControl has been interacted with.
    * (triggered by blur event)
    */
-  touched: boolean;
+  _touched: boolean;
   /** The initial value of the FormControl. Defaults to `""` if not set via `useForm(params)`. */
-  readonly initial: string;
+  initial: string;
+  private readonly formRef;
+  private _value;
   get value(): string;
+  get touched(): boolean;
+  /**
+   * This will only change the internal value of the control, not the one displayed in the actual HTML-Element
+   *
+   * See `change(value: String)` for doing both
+   */
   set value(value: string);
-/**
+  set touched(value: boolean);
+  constructor(formControl: {
+    value: string;
+    validators: Validator[];
+    errorMap: ErrorMap;
+    elements: FormControlElement[];
+    formRef: () => Form<any>;
+  });
+  /**
    * Set an error manually.
    *
    * The error will be removed after changes to the value or on validate()
    *
    * Used for setting an error that would be difficult to implement with a validator.
-   * e.g. Backend Response returning Login failed
+   * @example Backend Response returning Login failed
    * ``` typescript
    * function submit() {
    *    apiLogin($form.values).then(response => {})
@@ -186,13 +208,17 @@ export declare class FormControl {
    * }
    * ```
    */
-  error(errors: ValidationErrors): void
+  error(errors: ValidationErrors): void;
+  /** Change the value and the value of all HTML-Elements associated with this control */
+  change(value: any): void;
   /** Validate the FormControl by querying through the given validators. */
   validate(): boolean;
+  /** Reset the form control value to its initial value or `{ value }` and untouch it */
+  reset({ value }?: { value?: string | null }): void;
 }
-```
+````
 
-### validators (Action)
+## `use:validators` (Action)
 
 Takes in the validators that should be used on the form control.
 e.g.
@@ -201,27 +227,26 @@ e.g.
 <input name="email" use:validators={[required, email]}>
 ```
 
-### Hint
+## Hint
 
 Properties:
 
-- for="name_of_input"
-- on="error" > the error which should trigger it
-- hideWhen="different_error" > hides the hint if the different error is throwing
-- hideWhenRequired > shortcut for hideWhen="required"
-- showWhenUntouched > hint will get displayed even if the field hasn't been touched yet.
-- class="classes"
-- let:value > returns the value of the error
+- `for="name_of_input"`
+- `on="error"` the error which should trigger it
+- `hideWhen="different_error"` hides the hint if the different error is throwing
+- `hideWhenRequired` shortcut for hideWhen="required"
+- `showWhenUntouched` hint will get displayed even if the field hasn't been touched yet.
+- `let:value` returns the value of the error
 
-### HintGroup
+## HintGroup
 
 Properties:
 
-- for="name_of_input"
+- `for="name_of_input"`
 
-You can omit the Hint "name" prop when wrapping it with a HintGroup.
+You can omit the Hint `name` prop when wrapping it with a HintGroup.
 
-### Validators
+## Validators
 
 - required
 - minLength(n)
@@ -230,7 +255,7 @@ You can omit the Hint "name" prop when wrapping it with a HintGroup.
 - email
 - url
 
-#### Custom Validator
+### Custom Validator
 
 A validator needs to be a function that returns null if valid else an object with the key being the name of the error. The value of the object will be accessible through the error. e.g. $form.title.errors.name_of_error -> 'info'.
 
@@ -252,8 +277,8 @@ function passwordMatch(value: string, form: Form): null | ValidationErrors {
 
 An example with [validator.js](https://www.npmjs.com/package/validator) [REPL](https://svelte.dev/repl/21fc7637645d4917994ad4140b54b871?version=3.35.0)
 
-## Note
+# Remarks
 
-### Chrome Autofill
+## Chrome Autofill
 
 When Chrome autofills the form on page load, it will register all inputs as valid. After clicking anywhere on the site, pressing a key or pressing the submit button it will validate all fields and set the correct state of the form. Note that when the user triggers a submit event, it will not fire if the fields are invalid. This solution was needed due to Chromes way of autofilling forms without really filling the inputs with values, until the page gets a click or key event.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <span align="left">Svelte Use Form</span>
   </h1>
 
-A svelte form library that is easy to use and has no boilerplate. It helps you control and validate forms and their fields and check on the state of them.
+A svelte form library that is easy to use and has no boilerplate. It lets you create and control complicated forms with ease. Like svelte, the focus is **DX** 💻‍✨
 
 ```bash
 npm i -D svelte-use-form
@@ -15,16 +15,16 @@ npm i -D svelte-use-form
 
 **Features:**
 
-- Supports: Inputs, TextAreas, Selects, Radio Buttons, Checkboxes...
-- Uses single object to represent the state, instead of splitting it up (errors, values, controls...)
-- Requires no special binding on the Form Input Elements, only the name attribute
-- OOTB validators and custom validator support
-- No requirement to use custom components
-- Works with dynamic inputs => Show / Hide Inputs at runtime.
+- Minimalistic approach. Don't write more than necessary. 😘
+- No new components, bindings or callbacks required! ✅
+- OOTB validators and custom validator support ✅
+- Works with dynamic inputs => Show / Hide Inputs at runtime. ✅
+- Type inference [TS] ✅
 
 # Usage
 
-It's pretty self-explanatory, just check out the examples below 😉<br>
+It's pretty self-explanatory… check out the examples below 😉
+
 Just make sure to prefix the form with `$`, when accessing its state.
 
 **Minimal Example** [REPL](https://svelte.dev/repl/faf5a9ab763640ed830028c970421f72?version=3.35.0)
@@ -89,11 +89,41 @@ or you could also print the error message like this:
 
 # API
 
-## `const form = useForm(FormProperties)`
+## `useForm(FormProperties | null)`
 
-useForm() returns a svelte `store` (Observable) that is also an `action`. (That's what I call [svelte](https://www.dictionary.com/browse/svelte) 😆)<br>
+useForm() returns a svelte `store` (Observable) that is also an `action`. (That's what I call [svelte](https://www.dictionary.com/browse/svelte) 😆)
 
-### FormProperties
+### Why specify `FormProperties`?
+
+Providing the names of the properties as arguments allows us to initialize all form controls in the form before the site is actually rendered. Thus you won't need to null-check them when accessing them.
+
+```svelte
+const form = useForm({ firstName: {} });
+$form.firstName // Works as expected
+$form?.lastName // lastName would be null on page load
+```
+
+### `$form`
+
+Subscribe to the form with `$`-prefix to access the state of the form. It returns a `Form` instance.
+
+### `Form`
+
+**Remark**: In reality the "Form" is an union of multiple types and its self.
+
+```typescript
+class Form {
+  valid: boolean;
+  touched: boolean;
+  values: {
+    [controlName: string]: string;
+  };
+  reset(): void;
+  [controlName: string]: FormControl | undefined;
+}
+```
+
+### `FormProperties` (Optional)
 
 ```typescript
 export type FormProperties = {
@@ -113,36 +143,16 @@ export type FormProperties = {
 };
 ```
 
-### form
-
-Contains an `action` that can be used on a `<form>`. It binds the form state to the form element.
-
-### $form
-
-Subscribe to the form with `$` prefix to access the state of the form. It returns a `Form` instance.
-
-### `Form`
-
-Remark: The "Form" is an union of multiple types and its self.
-
-```typescript
-class Form {
-  valid: boolean;
-  touched: boolean;
-  values: {
-    [formControlName: string]: string;
-  };
-  reset(): void;
-  [formControlName: string]: FormControl;
-}
-```
-
-Every form control in the form will be accessible through $form directly via the name attribute. e.g. `<input name="email" />` === $form.email
-
 ## `FormControl`
 
+A FormControl represents an input of the form. (input, textarea, radio, select...)
+
+**Important**:
+Every control in the form will be accessible through $form directly via the name attribute.
+
+e.g. `<input name="email" />` --> `$form.email`
+
 ````typescript
-/** A FormControl represents the state of a {@link FormControlElement} like (input, textarea...) */
 export declare class FormControl {
   validators: Validator[];
   /**
@@ -227,7 +237,9 @@ e.g.
 <input name="email" use:validators={[required, email]}>
 ```
 
-## Hint
+## `<Hint></Hint>`
+
+Helper component for displaying information based on errors in an input.
 
 Properties:
 
@@ -238,22 +250,22 @@ Properties:
 - `showWhenUntouched` hint will get displayed even if the field hasn't been touched yet.
 - `let:value` returns the value of the error
 
-## HintGroup
+## `<HintGroup><Hint></Hint></HintGroup>`
+
+You can omit the Hint `name` prop when wrapping it with a HintGroup.
 
 Properties:
 
 - `for="name_of_input"`
 
-You can omit the Hint `name` prop when wrapping it with a HintGroup.
-
 ## Validators
 
-- required
-- minLength(n)
-- maxLength(n)
-- number
-- email
-- url
+- `required`
+- `minLength(n)`
+- `maxLength(n)`
+- `number`
+- `email`
+- `url`
 
 ### Custom Validator
 
@@ -279,6 +291,9 @@ An example with [validator.js](https://www.npmjs.com/package/validator) [REPL](h
 
 # Remarks
 
-## Chrome Autofill
+## Chrome Autofill Solution
 
-When Chrome autofills the form on page load, it will register all inputs as valid. After clicking anywhere on the site, pressing a key or pressing the submit button it will validate all fields and set the correct state of the form. Note that when the user triggers a submit event, it will not fire if the fields are invalid. This solution was needed due to Chromes way of autofilling forms without really filling the inputs with values, until the page gets a click or key event.
+When Chrome autofills the form on page load, it will always register all inputs as valid. After clicking anywhere on the site, pressing a key or pressing the submit button it will then reevaluate all fields and update the state of the form. 
+
+This solution was needed due to Chrome's way of autofilling forms without actually setting the value of the inputs until the page gets a click or key event.
+

--- a/src/app.html
+++ b/src/app.html
@@ -6,8 +6,6 @@
 	<link rel="icon" href="/favicon.png" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	%svelte.head%
-
-	<script src="https://unpkg.com/validator@latest/validator.min.js"></script>
 </head>
 
 <body>

--- a/src/app.html
+++ b/src/app.html
@@ -1,12 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" href="/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		%svelte.head%
-	</head>
-	<body>
-		<div id="svelte">%svelte.body%</div>
-	</body>
+
+<head>
+	<meta charset="utf-8" />
+	<link rel="icon" href="/favicon.png" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	%svelte.head%
+
+	<script src="https://unpkg.com/validator@latest/validator.min.js"></script>
+</head>
+
+<body>
+	<div id="svelte">%svelte.body%</div>
+</body>
+
 </html>

--- a/src/lib/chromeAutofill.ts
+++ b/src/lib/chromeAutofill.ts
@@ -1,5 +1,5 @@
 import type { FormControl } from "./models/formControl";
-import type { TextElement } from "./models/formElements";
+import type { TextElement } from "./models/formControlElement";
 
 const isChrome = () =>
   /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);

--- a/src/lib/chromeAutofill.ts
+++ b/src/lib/chromeAutofill.ts
@@ -1,5 +1,5 @@
 import type { FormControl } from "./models/formControl";
-import type { TextElement } from "./models/formMembers";
+import type { TextElement } from "./models/formElements";
 
 const isChrome = () =>
   /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);

--- a/src/lib/components/Hint.svelte
+++ b/src/lib/components/Hint.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { getContext } from "svelte";
-  import { compute_rest_props } from "svelte/internal";
   import type { Form } from "../models/form";
 
   /**
    * The name of the form control.
    *
-   * Can be omitted when using a wrapping HintGroup setting the `for` property.
+   * @remarks Can be omitted when using a wrapping HintGroup setting the `for` property.
+   * @exmaple
    * ``` svelte
    * <input name="nameOfFormControl" use:validators={[required]} />
    * <Hint for="nameOfFormControl" on="required">HINT</Hint>
@@ -38,7 +38,7 @@
   if (!name) name = getContext("svelte-use-form_hint-group-name");
 
   const form: {
-    subscribe: (callback: (form: Form) => any) => void;
+    subscribe: (callback: (form: Form<any>) => any) => void;
   } = getContext("svelte-use-form_form");
 
   $: touched = $form[name]?.touched ?? {};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,9 +1,13 @@
 export { default as Hint } from "./components/Hint.svelte";
 export { default as HintGroup } from "./components/HintGroup.svelte";
 export { useForm } from "./useForm";
-export { validators } from "./validatorsAction";
-export { Form } from "./models/form";
+export { validators, ValidatorsActionError } from "./validatorsAction";
+export { Form, FormFormControlMissingError } from "./models/form";
 export { FormControl } from "./models/formControl";
+export type {
+  FormControlsSpecified,
+  FormControlsUnspecified,
+} from "./models/form";
 export {
   required,
   minLength,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,7 +2,7 @@ export { default as Hint } from "./components/Hint.svelte";
 export { default as HintGroup } from "./components/HintGroup.svelte";
 export { useForm } from "./useForm";
 export { validators, ValidatorsActionError } from "./validatorsAction";
-export { Form, FormFormControlMissingError } from "./models/form";
+export { Form, FormControlMissingError } from "./models/form";
 export { FormControl } from "./models/formControl";
 export type {
   FormControlsSpecified,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -16,5 +16,4 @@ export {
   url,
   number,
 } from "./validators";
-export type { Validator } from "./models/validator";
-export type { ValidationErrors } from "./models/validationErrors";
+export type { Validator, ValidationErrors, ErrorMap } from "./models/validator";

--- a/src/lib/models/errorMap.ts
+++ b/src/lib/models/errorMap.ts
@@ -1,1 +1,0 @@
-export type ErrorMap = { [errorName: string]: string | ((error: any) => any) };

--- a/src/lib/models/form.ts
+++ b/src/lib/models/form.ts
@@ -1,8 +1,7 @@
-import type { ErrorMap } from "./errorMap";
 import { FormControl } from "./formControl";
 import type { FormElement } from "./formElements";
 import type { FormProperties } from "./formProperties";
-import type { Validator } from "./validator";
+import type { ErrorMap, Validator } from "./validator";
 
 export class Form<Keys extends keyof any> {
   static create<Keys extends keyof any>(
@@ -62,6 +61,7 @@ export class Form<Keys extends keyof any> {
     this.forEachFormControl((formControl) => formControl.reset());
   }
 
+  /** @internal */
   _addFormControl(
     name: string,
     initial: string = "",
@@ -91,8 +91,9 @@ export class Form<Keys extends keyof any> {
 
 export class FormFormControlMissingError extends Error {}
 
+// We do not use utility types here, since they would hide the name of the type
 export type FormControlsUnspecified = {
-  [key: string]: FormControl | undefined;
+  [key: string]: FormControl | undefined;
 };
 export type FormControlsSpecified<Keys extends keyof any> = {
   [K in Keys]: FormControl;

--- a/src/lib/models/form.ts
+++ b/src/lib/models/form.ts
@@ -1,19 +1,8 @@
 import type { ErrorMap } from "./errorMap";
 import { FormControl } from "./formControl";
-import type { FormMember } from "./formMembers";
+import type { FormElement } from "./formElements";
 import type { FormProperties } from "./formProperties";
 import type { Validator } from "./validator";
-
-export type FormControlsUnspecified = Partial<Record<string, FormControl>>;
-
-export type FormControlsSpecified<Keys extends keyof any> = {
-  [K in Keys]: FormControl;
-};
-
-export type FormValues<Keys extends keyof any> = Partial<
-  Record<string, string | null>
-> &
-  Record<Keys, string>;
 
 export class Form<Keys extends keyof any> {
   static create<Keys extends keyof any>(
@@ -74,22 +63,22 @@ export class Form<Keys extends keyof any> {
 
   _addFormControl(
     name: string,
-    initial: string,
-    validators: Validator[],
-    elements: FormMember[],
-    errorMap: ErrorMap
+    initial: string = "",
+    validators: Validator[] = [],
+    elements: FormElement[] = [],
+    errorMap: ErrorMap = {}
   ) {
     this[name] = new FormControl({
-      value: initial ?? "",
-      validators: validators ?? [],
-      errorMap: errorMap ?? {},
-      elements: elements ?? [],
+      value: initial,
+      validators: validators,
+      elements: elements,
+      errorMap: errorMap,
       formRef: () => this,
     });
   }
 
   private forEachFormControl(
-    callback: (formControl: FormControl, key?: string) => void
+    callback: (formControl: FormControl, key: string) => void
   ) {
     for (const [key, value] of Object.entries(this)) {
       if (value instanceof FormControl) {
@@ -98,3 +87,14 @@ export class Form<Keys extends keyof any> {
     }
   }
 }
+
+export class FormFormControlMissingError extends Error {}
+
+export type FormControlsUnspecified = Partial<Record<string, FormControl>>;
+export type FormControlsSpecified<Keys extends keyof any> = {
+  [K in Keys]: FormControl;
+};
+export type FormValues<Keys extends keyof any> = Partial<
+  Record<string, string>
+> &
+  Record<Keys, string>;

--- a/src/lib/models/form.ts
+++ b/src/lib/models/form.ts
@@ -90,7 +90,7 @@ export class Form<Keys extends keyof any> {
 
 export class FormFormControlMissingError extends Error {}
 
-export type FormControlsUnspecified = Partial<Record<string, FormControl>>;
+export type FormControlsUnspecified = { [key: string]: FormControl | undefined };
 export type FormControlsSpecified<Keys extends keyof any> = {
   [K in Keys]: FormControl;
 };

--- a/src/lib/models/form.ts
+++ b/src/lib/models/form.ts
@@ -20,7 +20,7 @@ export class Form<Keys extends keyof any> {
 
   get valid(): boolean {
     let valid = true;
-    this.forEachFormControl((formControl) => {
+    this.forEachControl((formControl) => {
       if (!formControl.valid) valid = false;
     });
     return valid;
@@ -28,7 +28,7 @@ export class Form<Keys extends keyof any> {
 
   get touched(): boolean {
     let touched = true;
-    this.forEachFormControl((formControl) => {
+    this.forEachControl((formControl) => {
       if (!formControl.touched) touched = false;
     });
     return touched;
@@ -36,7 +36,7 @@ export class Form<Keys extends keyof any> {
 
   get values(): FormValues<Keys> {
     let values = {} as any;
-    this.forEachFormControl((formControl, key) => {
+    this.forEachControl((formControl, key) => {
       values[key] = formControl.value;
     });
 
@@ -44,7 +44,7 @@ export class Form<Keys extends keyof any> {
   }
 
   set touched(value: boolean) {
-    this.forEachFormControl((formControl) => {
+    this.forEachControl((formControl) => {
       formControl.touched = value;
     });
 
@@ -53,7 +53,7 @@ export class Form<Keys extends keyof any> {
 
   private constructor(initialData: FormProperties, notifyListeners: Function) {
     for (const [k, v] of Object.entries(initialData)) {
-      this._addFormControl(k, v.initial, v.validators, [], v.errorMap);
+      this._addControl(k, v.initial, v.validators, [], v.errorMap);
     }
 
     this._notifyListeners = notifyListeners;
@@ -61,11 +61,11 @@ export class Form<Keys extends keyof any> {
 
   /** Reset the whole form */
   reset() {
-    this.forEachFormControl((formControl) => formControl.reset());
+    this.forEachControl((formControl) => formControl.reset());
   }
 
-  /** @internal */
-  _addFormControl(
+  /** @internal Add a form conrol to the Form */
+  _addControl(
     name: string,
     initial: string = "",
     validators: Validator[] = [],
@@ -81,7 +81,7 @@ export class Form<Keys extends keyof any> {
     });
   }
 
-  private forEachFormControl(
+  private forEachControl(
     callback: (formControl: FormControl, key: string) => void
   ) {
     for (const [key, value] of Object.entries(this)) {
@@ -92,7 +92,7 @@ export class Form<Keys extends keyof any> {
   }
 }
 
-export class FormFormControlMissingError extends Error {}
+export class FormControlMissingError extends Error {}
 
 // We do not use utility types here, since they would hide the name of the type
 export type FormControlsUnspecified = {

--- a/src/lib/models/form.ts
+++ b/src/lib/models/form.ts
@@ -58,6 +58,7 @@ export class Form<Keys extends keyof any> {
 
   /** Reset the whole form */
   reset() {
+    console.log(this);
     this.forEachFormControl((formControl) => formControl.reset());
   }
 
@@ -90,7 +91,9 @@ export class Form<Keys extends keyof any> {
 
 export class FormFormControlMissingError extends Error {}
 
-export type FormControlsUnspecified = { [key: string]: FormControl | undefined };
+export type FormControlsUnspecified = {
+  [key: string]: FormControl | undefined;
+};
 export type FormControlsSpecified<Keys extends keyof any> = {
   [K in Keys]: FormControl;
 };

--- a/src/lib/models/form.ts
+++ b/src/lib/models/form.ts
@@ -1,9 +1,13 @@
 import { FormControl } from "./formControl";
-import type { FormElement } from "./formElements";
+import type { FormControlElement } from "./formControlElement";
 import type { FormProperties } from "./formProperties";
 import type { ErrorMap, Validator } from "./validator";
 
 export class Form<Keys extends keyof any> {
+  /**
+   * Function for creating a Form
+   * @remarks This allows us to specify the index signatures in the class
+   */
   static create<Keys extends keyof any>(
     initialData: FormProperties,
     notifyListeners: Function
@@ -57,7 +61,6 @@ export class Form<Keys extends keyof any> {
 
   /** Reset the whole form */
   reset() {
-    console.log(this);
     this.forEachFormControl((formControl) => formControl.reset());
   }
 
@@ -66,7 +69,7 @@ export class Form<Keys extends keyof any> {
     name: string,
     initial: string = "",
     validators: Validator[] = [],
-    elements: FormElement[] = [],
+    elements: FormControlElement[] = [],
     errorMap: ErrorMap = {}
   ) {
     this[name] = new FormControl({

--- a/src/lib/models/formControl.ts
+++ b/src/lib/models/formControl.ts
@@ -151,8 +151,8 @@ export class FormControl {
   }
 
   /** Reset the form control value to its initial value or `{ value }` and untouch it */
-  reset({ value = this.initial }: { value?: string } = {}) {
-    const resetValue = value !== null ? value : this.initial;
+  reset({ value }: { value?: string | null } = {}) {
+    const resetValue = value == null ? this.initial : value;
     this.elements.forEach((element) => (element.value = resetValue));
     this.value = resetValue;
     this.touched = false;

--- a/src/lib/models/formControl.ts
+++ b/src/lib/models/formControl.ts
@@ -1,5 +1,5 @@
 import type { Form } from "./form";
-import type { FormElement } from "./formElements";
+import type { FormControlElement } from "./formControlElement";
 import type { Validator, ValidationErrors, ErrorMap } from "./validator";
 
 /** A FormControl represents the state of a form member like (input, textarea...) */
@@ -25,7 +25,7 @@ export class FormControl {
   /**
    * The DOM elements representing this control
    */
-  elements: FormElement[] = [];
+  elements: FormControlElement[] = [];
 
   /** Does the FormControl pass all given validators? */
   valid = true;
@@ -39,7 +39,7 @@ export class FormControl {
   /** The initial value of the FormControl. Defaults to `""` if not set via `useForm(params)`. */
   initial: string;
 
-  // Todo can we get the Form via Svelte context?
+  // TODO can we get the Form via Svelte context?
   private readonly formRef: () => Form<any>;
 
   private _value: string;
@@ -74,7 +74,7 @@ export class FormControl {
     value: string;
     validators: Validator[];
     errorMap: ErrorMap;
-    elements: FormElement[];
+    elements: FormControlElement[];
     formRef: () => Form<any>;
   }) {
     this.formRef = formControl.formRef;

--- a/src/lib/models/formControl.ts
+++ b/src/lib/models/formControl.ts
@@ -10,9 +10,10 @@ export class FormControl {
 
   /**
    * Returns an object containing possible ValidationErrors
-   * ### Example (All validators are throwing an error)
+   * @example
+   * (All validators are throwing an error)
    * `{ required: true, minLength: 4, maxLength: 20 }`
-   * ### Example 2 (Only required is not valid)
+   * (Only required is not valid)
    * `{ required: true }`
    */
   errors: ValidationErrors = {};
@@ -28,7 +29,7 @@ export class FormControl {
    */
   elements: FormElement[] = [];
 
-  /** If the FormControl passed all given validators. */
+  /** Does the FormControl pass all given validators? */
   valid = true;
 
   /**
@@ -92,7 +93,7 @@ export class FormControl {
    * The error will be removed after changes to the value or on validate()
    *
    * Used for setting an error that would be difficult to implement with a validator.
-   * e.g. Backend Response returning Login failed
+   * @example Backend Response returning Login failed
    * ``` typescript
    * function submit() {
    *    apiLogin($form.values).then(response => {})
@@ -108,11 +109,11 @@ export class FormControl {
     this.errors = { ...errors, ...this.errors };
     this.valid = false;
 
-    // Updating the $form
+    // Update the $form
     this.formRef()["_notifyListeners"]();
   }
 
-  /** Change the internal value and the value of all HTML-Elements associated with this control */
+  /** Change the value and the value of all HTML-Elements associated with this control */
   change(value: any) {
     this.value = value;
     this.elements.forEach((element) => (element.value = value));
@@ -149,8 +150,8 @@ export class FormControl {
     return valid;
   }
 
-  /** Reset the form control value to its initial value and untouch it */
-  reset({ value = null } = {}) {
+  /** Reset the form control value to its initial value or `{ value }` and untouch it */
+  reset({ value }: { value: string | null }) {
     const resetValue = value !== null ? value : this.initial;
     this.elements.forEach((element) => (element.value = resetValue));
     this.value = resetValue;

--- a/src/lib/models/formControl.ts
+++ b/src/lib/models/formControl.ts
@@ -1,6 +1,6 @@
 import type { ErrorMap } from "./errorMap";
 import type { Form } from "./form";
-import type { FormMember } from "./formMembers";
+import type { FormElement } from "./formElements";
 import type { ValidationErrors } from "./validationErrors";
 import type { Validator } from "./validator";
 
@@ -26,7 +26,7 @@ export class FormControl {
   /**
    * The DOM elements representing this control
    */
-  elements: FormMember[] = [];
+  elements: FormElement[] = [];
 
   /** If the FormControl passed all given validators. */
   valid = true;
@@ -40,7 +40,8 @@ export class FormControl {
   /** The initial value of the FormControl. Defaults to `""` if not set via `useForm(params)`. */
   initial: string;
 
-  private readonly formRef: () => Form;
+  // Todo can we get the Form via Svelte context?
+  private readonly formRef: () => Form<any>;
 
   private _value: string;
 
@@ -74,8 +75,8 @@ export class FormControl {
     value: string;
     validators: Validator[];
     errorMap: ErrorMap;
-    elements: FormMember[];
-    formRef: () => Form;
+    elements: FormElement[];
+    formRef: () => Form<any>;
   }) {
     this.formRef = formControl.formRef;
     this.validators = formControl.validators;

--- a/src/lib/models/formControl.ts
+++ b/src/lib/models/formControl.ts
@@ -1,8 +1,6 @@
-import type { ErrorMap } from "./errorMap";
 import type { Form } from "./form";
 import type { FormElement } from "./formElements";
-import type { ValidationErrors } from "./validationErrors";
-import type { Validator } from "./validator";
+import type { Validator, ValidationErrors, ErrorMap } from "./validator";
 
 /** A FormControl represents the state of a form member like (input, textarea...) */
 export class FormControl {
@@ -126,19 +124,22 @@ export class FormControl {
 
     for (const validator of this.validators) {
       const errors = validator(this._value, this.formRef());
-      if (errors) {
-        valid = false;
-        for (const error of Object.entries(errors)) {
-          let [key, value] = error;
+      if (!errors) continue;
 
-          // If there is a map for the error, use it
-          const errorMap = this.errorMap[key];
-          if (errorMap) {
-            value = typeof errorMap === "function" ? errorMap(value) : errorMap;
-          }
+      valid = false;
+      for (const error of Object.entries(errors)) {
+        let [key, value] = error;
 
-          this.errors[key] = value;
-        }
+        // If there is a map for the error, use it
+        const errorMapping = this.errorMap[key];
+        if (!errorMapping) continue;
+
+        value =
+          typeof errorMapping === "function"
+            ? errorMapping(value)
+            : errorMapping;
+
+        this.errors[key] = value;
       }
     }
 

--- a/src/lib/models/formControl.ts
+++ b/src/lib/models/formControl.ts
@@ -151,7 +151,7 @@ export class FormControl {
   }
 
   /** Reset the form control value to its initial value or `{ value }` and untouch it */
-  reset({ value }: { value: string | null }) {
+  reset({ value = this.initial }: { value?: string } = {}) {
     const resetValue = value !== null ? value : this.initial;
     this.elements.forEach((element) => (element.value = resetValue));
     this.value = resetValue;

--- a/src/lib/models/formControl.ts
+++ b/src/lib/models/formControl.ts
@@ -2,16 +2,16 @@ import type { Form } from "./form";
 import type { FormControlElement } from "./formControlElement";
 import type { Validator, ValidationErrors, ErrorMap } from "./validator";
 
-/** A FormControl represents the state of a form member like (input, textarea...) */
+/** A FormControl represents the state of a {@link FormControlElement} like (input, textarea...) */
 export class FormControl {
   validators: Validator[];
 
   /**
-   * Returns an object containing possible ValidationErrors
+   * Returns an object containing possible validation errors
    * @example
    * (All validators are throwing an error)
    * `{ required: true, minLength: 4, maxLength: 20 }`
-   * (Only required is not valid)
+   * (Only required is invalid)
    * `{ required: true }`
    */
   errors: ValidationErrors = {};

--- a/src/lib/models/formControlElement.ts
+++ b/src/lib/models/formControlElement.ts
@@ -4,7 +4,7 @@ export function isTextElement(node: any): node is TextElement {
   );
 }
 
-export function isFormElement(node: any): node is FormElement {
+export function isFormControlElement(node: any): node is FormControlElement {
   return (
     node instanceof HTMLInputElement ||
     node instanceof HTMLTextAreaElement ||
@@ -13,4 +13,4 @@ export function isFormElement(node: any): node is FormElement {
 }
 
 export type TextElement = HTMLInputElement | HTMLTextAreaElement;
-export type FormElement = TextElement | HTMLSelectElement;
+export type FormControlElement = TextElement | HTMLSelectElement;

--- a/src/lib/models/formElements.ts
+++ b/src/lib/models/formElements.ts
@@ -1,6 +1,3 @@
-export type TextElement = HTMLInputElement | HTMLTextAreaElement;
-export type FormElement = TextElement | HTMLSelectElement;
-
 export function isTextElement(node: any): node is TextElement {
   return (
     node instanceof HTMLInputElement || node instanceof HTMLTextAreaElement
@@ -14,3 +11,6 @@ export function isFormElement(node: any): node is FormElement {
     node instanceof HTMLSelectElement
   );
 }
+
+export type TextElement = HTMLInputElement | HTMLTextAreaElement;
+export type FormElement = TextElement | HTMLSelectElement;

--- a/src/lib/models/formElements.ts
+++ b/src/lib/models/formElements.ts
@@ -1,13 +1,13 @@
 export type TextElement = HTMLInputElement | HTMLTextAreaElement;
-export type FormMember = TextElement | HTMLSelectElement;
+export type FormElement = TextElement | HTMLSelectElement;
 
-export function isTextElement(node): node is TextElement {
+export function isTextElement(node: any): node is TextElement {
   return (
     node instanceof HTMLInputElement || node instanceof HTMLTextAreaElement
   );
 }
 
-export function isFormMember(node): node is FormMember {
+export function isFormElement(node: any): node is FormElement {
   return (
     node instanceof HTMLInputElement ||
     node instanceof HTMLTextAreaElement ||

--- a/src/lib/models/formProperties.ts
+++ b/src/lib/models/formProperties.ts
@@ -1,5 +1,4 @@
-import type { ErrorMap } from "./errorMap";
-import type { Validator } from "./validator";
+import type { ErrorMap, Validator } from "./validator";
 
 export type FormProperties = {
   [key: string]: {
@@ -8,9 +7,10 @@ export type FormProperties = {
     /** The validators that will be checked when the input changes */
     validators?: Validator[];
     /**
-     * The map through which validation errors will be passed.
-     *
+     * The map through which validation errors will be mapped.
      * You can either pass a string or a function returning a new error value
+     *
+     * **Think of it as a translation map. 😆**
      */
     errorMap?: ErrorMap;
   };

--- a/src/lib/models/formProperties.ts
+++ b/src/lib/models/formProperties.ts
@@ -1,8 +1,8 @@
 import type { ErrorMap } from "./errorMap";
 import type { Validator } from "./validator";
 
-export interface FormProperties {
-  [control: string]: {
+export type FormProperties = {
+  [key: string]: {
     /** Initial value of the form control */
     initial?: string;
     /** The validators that will be checked when the input changes */
@@ -14,4 +14,4 @@ export interface FormProperties {
      */
     errorMap?: ErrorMap;
   };
-}
+};

--- a/src/lib/models/validationErrors.ts
+++ b/src/lib/models/validationErrors.ts
@@ -1,2 +1,0 @@
-/** An object that contains errors thrown by the validator. */
-export type ValidationErrors = { [errorName: string]: any };

--- a/src/lib/models/validator.ts
+++ b/src/lib/models/validator.ts
@@ -1,8 +1,12 @@
 import type { Form } from "./form";
-import type { ValidationErrors } from "./validationErrors";
 
 /** A function that either returns `null | undefined` when the value is valid or else an `ValidationErrors` object. */
 export type Validator = (
   value: string,
   form?: Form<any>
 ) => ValidationErrors | (null | undefined);
+
+/** An object that contains errors thrown by the validator. */
+export type ValidationErrors = { [errorName: string]: any };
+
+export type ErrorMap = { [errorName: string]: string | ((error: any) => any) };

--- a/src/lib/models/validator.ts
+++ b/src/lib/models/validator.ts
@@ -1,7 +1,7 @@
 import type { Form } from "./form";
 import type { ValidationErrors } from "./validationErrors";
 
-/** A function that either returns null when the value is valid and else an `ValidationErrors` object. */
+/** A function that either returns `null | undefined` when the value is valid or else an `ValidationErrors` object. */
 export type Validator = (
   value: string,
   form?: Form<any>

--- a/src/lib/models/validator.ts
+++ b/src/lib/models/validator.ts
@@ -2,4 +2,7 @@ import type { Form } from "./form";
 import type { ValidationErrors } from "./validationErrors";
 
 /** A function that either returns null when the value is valid and else an `ValidationErrors` object. */
-export type Validator = (value: string, form?: Form) => null | ValidationErrors;
+export type Validator = (
+  value: string,
+  form?: Form<any>
+) => ValidationErrors | (null | undefined);

--- a/src/lib/stores/formReferences.ts
+++ b/src/lib/stores/formReferences.ts
@@ -2,7 +2,7 @@ import { writable } from "svelte/store";
 import type { Form } from "../models/form";
 
 type FormReference = {
-  form: Form;
+  form: Form<any>;
   node: HTMLFormElement;
   notifyListeners: Function;
 };

--- a/src/lib/useForm.ts
+++ b/src/lib/useForm.ts
@@ -44,7 +44,7 @@ interface EventListener {
  * ```
  */
 export function useForm<Keys extends keyof T, T extends FormProperties = any>(
-  properties: T | FormProperties = Object.create(null)
+  properties: T | FormProperties = {} as FormProperties
 ) {
   const eventListeners: EventListener[] = [];
   const subscribers: Function[] = [];
@@ -304,10 +304,10 @@ export function useForm<Keys extends keyof T, T extends FormProperties = any>(
   }
 
   function setInitialValue(
-    formElement: FormControlElement,
+    element: FormControlElement,
     formControl: FormControl
   ) {
-    if (formControl.initial) formElement.value = formControl.initial;
+    if (formControl.initial) element.value = formControl.initial;
   }
 
   function notifyListeners() {

--- a/src/lib/useForm.ts
+++ b/src/lib/useForm.ts
@@ -1,6 +1,6 @@
 import { setContext } from "svelte";
 import { handleChromeAutofill } from "./chromeAutofill";
-import { Form, FormFormControlMissingError } from "./models/form";
+import { Form, FormControlMissingError } from "./models/form";
 import {
   FormControlElement,
   isFormControlElement,
@@ -104,7 +104,7 @@ export function useForm<Keys extends keyof T, T extends FormProperties = any>(
       // TextElement doesn't have FormControl yet (TextElement wasn't statically provided)
       if (!formControl) {
         const initial = getInitialValueFromTextElement(textElement);
-        state._addFormControl(name, initial, [], [textElement], {});
+        state._addControl(name, initial, [], [textElement], {});
         formControl = state[name]!;
       } else {
         formControl.elements.push(textElement);
@@ -139,7 +139,7 @@ export function useForm<Keys extends keyof T, T extends FormProperties = any>(
 
       if (!formControl) {
         const initial = selectElement.value;
-        state._addFormControl(name, initial, [], [selectElement], {});
+        state._addControl(name, initial, [], [selectElement], {});
       } else {
         formControl.elements.push(selectElement);
         setInitialValue(selectElement, formControl);
@@ -203,7 +203,7 @@ export function useForm<Keys extends keyof T, T extends FormProperties = any>(
             for (const element of [...textElements, ...selectElements]) {
               const initialFormControlProperty = properties[element.name];
               if (!state[element.name] && initialFormControlProperty) {
-                state._addFormControl(
+                state._addControl(
                   element.name,
                   initialFormControlProperty.initial,
                   initialFormControlProperty.validators,
@@ -262,7 +262,7 @@ export function useForm<Keys extends keyof T, T extends FormProperties = any>(
     if (isFormControlElement(node)) {
       const name = node.name;
       const formControl = state[name];
-      if (!formControl) throw new FormFormControlMissingError();
+      if (!formControl) throw new FormControlMissingError();
 
       let value: string;
       if (node.type === "checkbox" && node instanceof HTMLInputElement) {
@@ -280,7 +280,7 @@ export function useForm<Keys extends keyof T, T extends FormProperties = any>(
   function handleBlurOrClick({ target: node }: Event) {
     if (isFormControlElement(node)) {
       const formControl = state[node.name];
-      if (!formControl) throw new FormFormControlMissingError();
+      if (!formControl) throw new FormControlMissingError();
 
       if (!formControl.touched) handleInput({ target: node } as any);
 

--- a/src/lib/useForm.ts
+++ b/src/lib/useForm.ts
@@ -45,7 +45,7 @@ interface EventListener {
  * ```
  */
 export function useForm<Keys extends keyof T, T extends FormProperties = any>(
-  properties: T = Object.create(null)
+  properties: T | FormProperties = Object.create(null)
 ) {
   const eventListeners: EventListener[] = [];
   const subscribers: Function[] = [];

--- a/src/lib/useForm.ts
+++ b/src/lib/useForm.ts
@@ -1,16 +1,15 @@
 import { setContext } from "svelte";
 import { handleChromeAutofill } from "./chromeAutofill";
 import { Form, FormFormControlMissingError } from "./models/form";
-import type { FormControl } from "./models/formControl";
-
 import {
-  FormElement,
-  isFormElement,
+  FormControlElement,
+  isFormControlElement,
   isTextElement,
   TextElement,
-} from "./models/formElements";
-import type { FormProperties } from "./models/formProperties";
+} from "./models/formControlElement";
 import { formReferences } from "./stores/formReferences";
+import type { FormControl } from "./models/formControl";
+import type { FormProperties } from "./models/formProperties";
 
 interface EventListener {
   node: HTMLElement;
@@ -171,7 +170,7 @@ export function useForm<Keys extends keyof T, T extends FormProperties = any>(
               ...textareaElements,
               ...selects,
             ];
-            if (isFormElement(node)) elements.push(node);
+            if (isFormControlElement(node)) elements.push(node);
 
             for (const element of elements) {
               for (const eventListener of eventListeners) {
@@ -260,7 +259,7 @@ export function useForm<Keys extends keyof T, T extends FormProperties = any>(
   }
 
   function handleInput({ target: node }: Event) {
-    if (isFormElement(node)) {
+    if (isFormControlElement(node)) {
       const name = node.name;
       const formControl = state[name];
       if (!formControl) throw new FormFormControlMissingError();
@@ -279,7 +278,7 @@ export function useForm<Keys extends keyof T, T extends FormProperties = any>(
   }
 
   function handleBlurOrClick({ target: node }: Event) {
-    if (isFormElement(node)) {
+    if (isFormControlElement(node)) {
       const formControl = state[node.name];
       if (!formControl) throw new FormFormControlMissingError();
 
@@ -292,7 +291,7 @@ export function useForm<Keys extends keyof T, T extends FormProperties = any>(
     }
   }
 
-  function hideNotRepresentedFormControls(nodes: FormElement[]) {
+  function hideNotRepresentedFormControls(nodes: FormControlElement[]) {
     for (const key of Object.keys(properties)) {
       let isFormControlRepresentedInDom = false;
 
@@ -304,7 +303,10 @@ export function useForm<Keys extends keyof T, T extends FormProperties = any>(
     }
   }
 
-  function setInitialValue(formElement: FormElement, formControl: FormControl) {
+  function setInitialValue(
+    formElement: FormControlElement,
+    formControl: FormControl
+  ) {
     if (formControl.initial) formElement.value = formControl.initial;
   }
 

--- a/src/lib/useForm.ts
+++ b/src/lib/useForm.ts
@@ -44,13 +44,13 @@ interface EventListener {
  * <input name="firstName" value="CACHED_NAME" use:validators={[required, maxLength(10)]} />
  * ```
  */
-export function useForm(properties?: FormProperties) {
-  properties = properties ?? {};
-
+export function useForm<Keys extends keyof T, T extends FormProperties = any>(
+  properties: T = Object.create(null)
+) {
   const eventListeners: EventListener[] = [];
   const subscribers = [];
 
-  let state: Form = new Form(properties, notifyListeners);
+  let state = Form.create<Keys>(properties, notifyListeners);
   let observer: MutationObserver;
 
   action.subscribe = subscribe;
@@ -321,7 +321,7 @@ export function useForm(properties?: FormProperties) {
     for (const callback of subscribers) callback(state);
   }
 
-  function subscribe(callback: (form: Form) => void) {
+  function subscribe(callback: (form: typeof state) => void) {
     subscribers.push(callback);
     callback(state);
 
@@ -334,6 +334,7 @@ export function useForm(properties?: FormProperties) {
   }
 
   function set(value) {
+    // TODO investigage what happens when different Keys are passed
     state = value;
 
     notifyListeners();

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,4 +1,4 @@
-import type { ValidationErrors } from "./models/validationErrors";
+import type { ValidationErrors } from "./models/validator";
 
 export function required(value: string): null | ValidationErrors {
   return value.trim() ? null : { required: "Required" };

--- a/src/lib/validatorsAction.ts
+++ b/src/lib/validatorsAction.ts
@@ -1,7 +1,7 @@
 import { tick } from "svelte";
 import { get } from "svelte/store";
 import { FormControl } from "./models/formControl";
-import type { FormElement } from "./models/formElements";
+import type { FormControlElement } from "./models/formControlElement";
 import type { Validator } from "./models/validator";
 import { formReferences } from "./stores/formReferences";
 
@@ -12,7 +12,7 @@ import { formReferences } from "./stores/formReferences";
  * <input name="nameOfInput" use:validators={[required, minLength(5), maxLength(20)]} />
  * ```
  */
-export function validators(node: FormElement, validators: Validator[]) {
+export function validators(node: FormControlElement, validators: Validator[]) {
   setupValidation();
 
   async function setupValidation() {

--- a/src/lib/validatorsAction.ts
+++ b/src/lib/validatorsAction.ts
@@ -12,11 +12,11 @@ import { formReferences } from "./stores/formReferences";
  * <input name="nameOfInput" use:validators={[required, minLength(5), maxLength(20)]} />
  * ```
  */
-export function validators(node: FormControlElement, validators: Validator[]) {
+export function validators(element: FormControlElement, validators: Validator[]) {
   setupValidation();
 
   async function setupValidation() {
-    const formElement = node.form;
+    const formElement = element.form;
     if (!formElement)
       throw new ValidatorsActionError(
         "HTML element doesn't have an ancestral form"
@@ -31,10 +31,10 @@ export function validators(node: FormControlElement, validators: Validator[]) {
         "HTML form doesn't have a svelte-use-form binded. (use:form)"
       );
 
-    const formControl = formReference.form[node.name];
+    const formControl = formReference.form[element.name];
     if (!(formControl instanceof FormControl))
       throw new ValidatorsActionError(
-        `Form Control [${node.name}] doesn't exist.`
+        `Form Control [${element.name}] doesn't exist.`
       );
     formControl.validators.push(...validators);
     formControl.validate();

--- a/src/lib/validatorsAction.ts
+++ b/src/lib/validatorsAction.ts
@@ -7,6 +7,7 @@ import { formReferences } from "./stores/formReferences";
 
 /**
  * Add validators to form control
+ * @example
  * ``` svelte
  * <input name="nameOfInput" use:validators={[required, minLength(5), maxLength(20)]} />
  * ```

--- a/src/lib/validatorsAction.ts
+++ b/src/lib/validatorsAction.ts
@@ -1,6 +1,7 @@
 import { tick } from "svelte";
 import { get } from "svelte/store";
-import type { FormMember } from "./models/formMembers";
+import { FormControl } from "./models/formControl";
+import type { FormElement } from "./models/formElements";
 import type { Validator } from "./models/validator";
 import { formReferences } from "./stores/formReferences";
 
@@ -10,19 +11,34 @@ import { formReferences } from "./stores/formReferences";
  * <input name="nameOfInput" use:validators={[required, minLength(5), maxLength(20)]} />
  * ```
  */
-export function validators(node: FormMember, validators: Validator[]) {
+export function validators(node: FormElement, validators: Validator[]) {
   setupValidation();
 
   async function setupValidation() {
     const formElement = node.form;
+    if (!formElement)
+      throw new ValidatorsActionError(
+        "HTML element doesn't have an ancestral form"
+      );
     await tick();
     const formReference = get(formReferences).find(
       (form) => form.node === formElement
     );
 
+    if (!formReference)
+      throw new ValidatorsActionError(
+        "HTML form doesn't have a svelte-use-form binded. (use:form)"
+      );
+
     const formControl = formReference.form[node.name];
+    if (!(formControl instanceof FormControl))
+      throw new ValidatorsActionError(
+        `Form Control [${node.name}] doesn't exist.`
+      );
     formControl.validators.push(...validators);
     formControl.validate();
     formReference.notifyListeners();
   }
 }
+
+export class ValidatorsActionError extends Error {}

--- a/src/routes/_NavigationBar.svelte
+++ b/src/routes/_NavigationBar.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  const examplePaths = ["login", "reset-form", "async", "reuse-form"];
+  const examplePaths = [
+    "login",
+    "reset-form",
+    "async",
+    "reuse-form",
+    "dynamic-typing",
+  ];
 
   const getTitle = (path: string) => {
     const words = path.split("-");

--- a/src/routes/examples/dynamic-typing.svelte
+++ b/src/routes/examples/dynamic-typing.svelte
@@ -13,14 +13,15 @@
     email: { initial: "Test" },
     password: { initial: "test" },
   });
-  $form.name?.value;
+  $form.name?.value; // ✅
   $form.email.value; // ✅
   $form.notSpecified?.value; // ⚠️ Unsure
 
+  // Specifying controls this way, does not initialize them like it would when given as arguemnts
+  // Still, the advantage is that you have better intellisense
   const form2 = useForm<"this" | "is" | "possible">();
-  $form2.possible?.value; // ✅
-  $form2.notSpecified?.value; // ⚠️ Unsure
-  $form2.values.name;
+  $form2.possible?.value; 
+  $form2.notSpecified?.value; // ✅
 
   $: console.log($form);
 </script>

--- a/src/routes/examples/dynamic-typing.svelte
+++ b/src/routes/examples/dynamic-typing.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import {
+    HintGroup,
+    Hint,
+    minLength,
+    useForm,
+    validators,
+    maxLength,
+    email,
+  } from "$lib";
+
+  const form = useForm({
+    email: { initial: "Test" },
+    password: { initial: "test" },
+  });
+  $form.email.value; // ✅
+  $form.notSpecified.value; // ⚠️ Unsure
+
+  const form2 = useForm<"this" | "is" | "possible">();
+  $form2.possible.value; // ✅
+  $form2.notSpecified.value; // ⚠️ Unsure
+  $form2.values.name;
+</script>
+
+<form use:form>
+  <!-- Email -->
+  <input
+    type="email"
+    name="email"
+    placeholder="Email"
+    use:validators={[email]}
+  />
+  <Hint for="email" on="email">Input is not a valid email</Hint>
+
+  <!-- Password -->
+  <input
+    type="password"
+    name="password"
+    placeholder="Password"
+    use:validators={[minLength(6), maxLength(12)]}
+  />
+
+  <input
+    type="text"
+    name="message"
+    placeholder="Message"
+    use:validators={[minLength(6), maxLength(12)]}
+  />
+  {$form.values.message}
+  <HintGroup for="password">
+    <Hint on="minLength" let:value>
+      The password is too short, min = {value}
+    </Hint>
+    <Hint on="maxLength" let:value>
+      The password is too long, max = {value}
+    </Hint>
+  </HintGroup>
+
+  <button on:click|preventDefault disabled={!$form.valid}>Login</button>
+</form>

--- a/src/routes/examples/dynamic-typing.svelte
+++ b/src/routes/examples/dynamic-typing.svelte
@@ -13,12 +13,13 @@
     email: { initial: "Test" },
     password: { initial: "test" },
   });
+  $form.name?.value;
   $form.email.value; // ✅
-  $form.notSpecified.value; // ⚠️ Unsure
+  $form.notSpecified?.value; // ⚠️ Unsure
 
   const form2 = useForm<"this" | "is" | "possible">();
-  $form2.possible.value; // ✅
-  $form2.notSpecified.value; // ⚠️ Unsure
+  $form2.possible?.value; // ✅
+  $form2.notSpecified?.value; // ⚠️ Unsure
   $form2.values.name;
 </script>
 
@@ -46,7 +47,6 @@
     placeholder="Message"
     use:validators={[minLength(6), maxLength(12)]}
   />
-  {$form.values.message}
   <HintGroup for="password">
     <Hint on="minLength" let:value>
       The password is too short, min = {value}
@@ -58,3 +58,7 @@
 
   <button on:click|preventDefault disabled={!$form.valid}>Login</button>
 </form>
+<pre>
+  {JSON.stringify($form, null, "\t")}
+  {console.log(JSON.stringify($form, null, " "))}
+</pre>

--- a/src/routes/examples/dynamic-typing.svelte
+++ b/src/routes/examples/dynamic-typing.svelte
@@ -21,6 +21,8 @@
   $form2.possible?.value; // ✅
   $form2.notSpecified?.value; // ⚠️ Unsure
   $form2.values.name;
+
+  $: console.log($form);
 </script>
 
 <form use:form>
@@ -60,5 +62,5 @@
 </form>
 <pre>
   {JSON.stringify($form, null, "\t")}
-  {console.log(JSON.stringify($form, null, " "))}
+
 </pre>

--- a/src/routes/examples/old-archive/Messages.svelte
+++ b/src/routes/examples/old-archive/Messages.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { useForm, validators, required } from "$lib";
-  import validator from "validator";
+  let validator: any;
 
   const form = useForm();
 

--- a/src/routes/examples/old-archive/Repl.svelte
+++ b/src/routes/examples/old-archive/Repl.svelte
@@ -13,7 +13,7 @@
   let showNameField = false;
 
   function cantBeBrown(value) {
-    if (value === "brown") return { cantBeBrown: true };
+    if (value === "brown") return { cantBeBrown: true }
   }
 </script>
 

--- a/src/routes/examples/reset-form.svelte
+++ b/src/routes/examples/reset-form.svelte
@@ -11,11 +11,11 @@
 
   const form = useForm();
 
-  const resetForm = $form.reset;
+  const resetForm = () => $form.reset();
 
   const resetFoo = () => {
-    $form.value1.reset({ value: "Foo" });
-    $form.value2.reset({ value: "Bar" });
+    $form.value1?.reset({ value: "Foo" });
+    $form.value2?.reset({ value: "Bar" });
   };
 </script>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,31 +1,32 @@
 {
-	"compilerOptions": {
-		"moduleResolution": "node",
-		"module": "es2020",
-		"lib": ["es2020", "DOM.Iterable"],
-		"target": "es2019",
-		/**
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "es2020",
+    "lib": ["es2020", "DOM.Iterable"],
+    "target": "es2019",
+    /**
 			svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript
 			to enforce using \`import type\` instead of \`import\` for Types.
 			*/
-		"importsNotUsedAsValues": "error",
-		"isolatedModules": true,
-		"resolveJsonModule": true,
-		/**
+    "importsNotUsedAsValues": "error",
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    /**
 			To have warnings/errors of the Svelte compiler at the correct position,
 			enable source maps by default.
 			*/
-		"sourceMap": true,
-		"esModuleInterop": true,
-		"skipLibCheck": true,
-		"forceConsistentCasingInFileNames": true,
-		"baseUrl": ".",
-		"allowJs": true,
-		"checkJs": true,
-		"paths": {
-			"$lib": ["src/lib"],
-			"$lib/*": ["src/lib/*"]
-		}
-	},
-	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.ts", "src/**/*.svelte"]
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "allowJs": true,
+    "checkJs": true,
+    "paths": {
+      "$lib": ["src/lib"],
+      "$lib/*": ["src/lib/*"]
+    },
+    "strictNullChecks": true
+  },
+  "include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.ts", "src/**/*.svelte"]
 }


### PR DESCRIPTION
Adds generics to the useForm call, enabling it to infer which fields exist in `$form` and `$form.values`.

This will ensure that the user has to null-check fields that he hasn't specified in the constructor. `$form.name.value` -> error, since it wasn't specified and needs to be checked like e.g. `$form.name?.value`