### PR TITLE
Add validator for emails with TLDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ And thus it won't be validated or observed for changes.
 - `maxLength(n)`
 - `number`
 - `email`
-- `email_with_tld`
+- `emailWithTld`
 - `url`
 - `pattern(regExp)`
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ And thus it won't be validated or observed for changes.
 - `maxLength(n)`
 - `number`
 - `email`
+- `email_with_tld`
 - `url`
 - `pattern(regExp)`
 

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -31,7 +31,7 @@ export const email: Validator = (value) => {
  * A variation of the `email` validator that requires a TLD component. Verifying
  * the validity of the TLD is not the responsibility of this validation library.
  */
-export const email_with_tld: Validator = (value) => {
+export const emailWithTld: Validator = (value) => {
   if (
     /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+$/.test(
       value
@@ -39,7 +39,7 @@ export const email_with_tld: Validator = (value) => {
   ) {
     return null;
   }
-  return { email_with_tld: {} };
+  return { emailWithTld: {} };
 };
 
 export const url: Validator = (value) => {

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -27,6 +27,21 @@ export const email: Validator = (value) => {
   return { email: {} };
 };
 
+/**
+ * A variation of the `email` validator that requires a TLD component. Verifying
+ * the validity of the TLD is not the responsibility of this validation library.
+ */
+export const email_with_tld: Validator = (value) => {
+  if (
+    /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+$/.test(
+      value
+    )
+  ) {
+    return null;
+  }
+  return { email_with_tld: {} };
+};
+
 export const url: Validator = (value) => {
   // https://stackoverflow.com/a/5717133/13475809
   var pattern = new RegExp(

--- a/src/routes/examples/email-validator/+page.svelte
+++ b/src/routes/examples/email-validator/+page.svelte
@@ -5,10 +5,14 @@
 </script>
 
 <form use:form>
-  <input id="email_field" name="email_field" use:validators={[emailWithTld]} />
+  <input
+    id="testEmailField"
+    name="testEmailField"
+    use:validators={[emailWithTld]}
+  />
   <input
     type="checkbox"
-    id="is-valid"
-    checked={!!$form.email_field?.errors.emailWithTld}
+    id="isValid"
+    checked={!!$form.testEmailField?.errors.emailWithTld}
   />
 </form>

--- a/src/routes/examples/email-validator/+page.svelte
+++ b/src/routes/examples/email-validator/+page.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { useForm, validators } from "$lib";
+  import { email_with_tld } from "$lib/validators";
+  const form = useForm();
+</script>
+
+<form use:form>
+  <input
+    id="email_field"
+    name="email_field"
+    use:validators={[email_with_tld]}
+  />
+  <input
+    type="checkbox"
+    id="is-valid"
+    checked={!!$form.email_field?.errors.email_with_tld}
+  />
+</form>

--- a/src/routes/examples/email-validator/+page.svelte
+++ b/src/routes/examples/email-validator/+page.svelte
@@ -1,18 +1,14 @@
 <script lang="ts">
   import { useForm, validators } from "$lib";
-  import { email_with_tld } from "$lib/validators";
+  import { emailWithTld } from "$lib/validators";
   const form = useForm();
 </script>
 
 <form use:form>
-  <input
-    id="email_field"
-    name="email_field"
-    use:validators={[email_with_tld]}
-  />
+  <input id="email_field" name="email_field" use:validators={[emailWithTld]} />
   <input
     type="checkbox"
     id="is-valid"
-    checked={!!$form.email_field?.errors.email_with_tld}
+    checked={!!$form.email_field?.errors.emailWithTld}
   />
 </form>

--- a/tests/email-validator.spec.ts
+++ b/tests/email-validator.spec.ts
@@ -10,10 +10,10 @@ const valid_emails = [
   "example_address_2@a.b.c",
 ];
 
-for (const address of valid_emails) {
-  test(`${address} should be considered valid by the "email_with_tld" validator`, async ({
-    page,
-  }) => {
+test(`Verify valid emails are marked as valid by the emailWithTld validator`, async ({
+  page,
+}) => {
+  for (const address of valid_emails) {
     await page.goto("examples/email-validator");
 
     const input = page.locator("#email_field");
@@ -22,8 +22,8 @@ for (const address of valid_emails) {
     await input.clear();
     await input.type(address);
     await expect(isRequiredErrorTriggered).not.toBeChecked();
-  });
-}
+  }
+});
 
 const invalid_emails = [
   "email@test",
@@ -38,10 +38,10 @@ const invalid_emails = [
   "@example.com",
 ];
 
-for (const address of invalid_emails) {
-  test(`${address} should be considered invalid by the "email_with_tld" validator`, async ({
-    page,
-  }) => {
+test(`Verify invalid emails are marked as invalid by the emailWithTld validator`, async ({
+  page,
+}) => {
+  for (const address of invalid_emails) {
     await page.goto("examples/email-validator");
 
     const input = page.locator("#email_field");
@@ -50,5 +50,5 @@ for (const address of invalid_emails) {
     await input.clear();
     await input.type(address);
     await expect(isRequiredErrorTriggered).toBeChecked();
-  });
-}
+  }
+});

--- a/tests/email-validator.spec.ts
+++ b/tests/email-validator.spec.ts
@@ -1,6 +1,6 @@
 import test, { expect } from "@playwright/test";
 
-const valid_emails = [
+const validEmails = [
   "email@test.com",
   "email@test.xyz",
   "email@test.a",
@@ -13,11 +13,12 @@ const valid_emails = [
 test(`Verify valid emails are marked as valid by the emailWithTld validator`, async ({
   page,
 }) => {
-  for (const address of valid_emails) {
+  for (const address of validEmails) {
     await page.goto("examples/email-validator");
 
-    const input = page.locator("#email_field");
-    const isRequiredErrorTriggered = page.locator("#is-valid");
+    const input = page.locator("#testEmailField");
+    console.log(input);
+    const isRequiredErrorTriggered = page.locator("#isValid");
 
     await input.clear();
     await input.type(address);
@@ -25,7 +26,7 @@ test(`Verify valid emails are marked as valid by the emailWithTld validator`, as
   }
 });
 
-const invalid_emails = [
+const invalidEmails = [
   "email@test",
   "example.address@noTLD",
   "example.com@a",
@@ -41,11 +42,12 @@ const invalid_emails = [
 test(`Verify invalid emails are marked as invalid by the emailWithTld validator`, async ({
   page,
 }) => {
-  for (const address of invalid_emails) {
+  for (const address of invalidEmails) {
     await page.goto("examples/email-validator");
 
-    const input = page.locator("#email_field");
-    const isRequiredErrorTriggered = page.locator("#is-valid");
+    const input = page.locator("#testEmailField");
+    console.log(input);
+    const isRequiredErrorTriggered = page.locator("#isValid");
 
     await input.clear();
     await input.type(address);

--- a/tests/email-validator.spec.ts
+++ b/tests/email-validator.spec.ts
@@ -1,0 +1,54 @@
+import test, { expect } from "@playwright/test";
+
+const valid_emails = [
+  "email@test.com",
+  "email@test.xyz",
+  "email@test.a",
+  "example.address@t.co",
+  "example.address@a.b.c.d.e.f.g",
+  "example_address@a.b.c",
+  "example_address_2@a.b.c",
+];
+
+for (const address of valid_emails) {
+  test(`${address} should be considered valid by the "email_with_tld" validator`, async ({
+    page,
+  }) => {
+    await page.goto("examples/email-validator");
+
+    const input = page.locator("#email_field");
+    const isRequiredErrorTriggered = page.locator("#is-valid");
+
+    await input.clear();
+    await input.type(address);
+    await expect(isRequiredErrorTriggered).not.toBeChecked();
+  });
+}
+
+const invalid_emails = [
+  "email@test",
+  "example.address@noTLD",
+  "example.com@a",
+  "example.com@a@.com",
+  "example@a@.com",
+  "example.com@.com",
+  "example@.com",
+  "example.com",
+  "example",
+  "@example.com",
+];
+
+for (const address of invalid_emails) {
+  test(`${address} should be considered invalid by the "email_with_tld" validator`, async ({
+    page,
+  }) => {
+    await page.goto("examples/email-validator");
+
+    const input = page.locator("#email_field");
+    const isRequiredErrorTriggered = page.locator("#is-valid");
+
+    await input.clear();
+    await input.type(address);
+    await expect(isRequiredErrorTriggered).toBeChecked();
+  });
+}


### PR DESCRIPTION
The `email` validator currently present in `svelte-use-form` doesn't force a TLD (as discussed https://github.com/noahsalvi/svelte-use-form/issues/59).

This PR adds an `email_with_tld` validator which is very similar to the `email` validator but forces a TLD component to the email host name.