### PR TITLE
Adds support for multiple values in Checkboxes and Selects

### DIFF
--- a/src/lib/chromeAutofill.ts
+++ b/src/lib/chromeAutofill.ts
@@ -28,7 +28,7 @@ function startAnimationWhenAutofilled() {
 
 export function handleChromeAutofill(
   textElement: TextElement,
-  control: FormControl,
+  control: FormControl<any>,
   callback: Function
 ) {
   if (!isChrome()) return;

--- a/src/lib/components/Hint.svelte
+++ b/src/lib/components/Hint.svelte
@@ -42,7 +42,7 @@
 
   const formContext: {
     subscribe: (
-      callback: (form: Form<any> & FormControlsUnspecified) => any
+      callback: (form: Form<any, any> & FormControlsUnspecified) => any
     ) => void;
   } = getContext(form);
 

--- a/src/lib/helpers/FormHelper.ts
+++ b/src/lib/helpers/FormHelper.ts
@@ -1,0 +1,59 @@
+import type { FormControlElement } from '$lib/models/formControlElement';
+
+export function setElementValue(element: FormControlElement, value: string | string[] | null) {
+    if (!value) return;
+
+    if (element instanceof HTMLSelectElement) {
+        if (element.multiple) {
+            [...element.options].forEach((option) => {
+                option.selected = (value as string[]).includes(option.value);
+            });
+        } else {
+            element.value = value as string;
+        }
+    } else if (element.type === 'radio' && element instanceof HTMLInputElement) {
+        element.checked = element.value === value;
+    } else if (
+        element.type === 'checkbox' &&
+        element instanceof HTMLInputElement
+    ) {
+        if (value instanceof Array) {
+            element.checked = value.includes(element.value);
+        } else {
+            element.checked = element.value === value;
+        }
+    } else {
+        element.value = value as string;
+    }
+}
+
+export function getElementValue(element: FormControlElement, allElements: FormControlElement[] = []): string | string[] {
+    if (element instanceof HTMLSelectElement) {
+        if (element.multiple) {
+            return [...element.selectedOptions].map((option) => option.value);
+        }
+
+        return element.value;
+    } else if (element.type === 'radio' && element instanceof HTMLInputElement) {
+        return element.checked ? element.value : '';
+    } else if (element.type === 'checkbox' && element instanceof HTMLInputElement) {
+        return getCheckboxValue(element, allElements);
+    } else {
+        return element.value;
+    }
+}
+
+
+function getCheckboxValue(element: HTMLInputElement, allElements: FormControlElement[]): string | string[] {
+    const name = element.name;
+    const matchingElements =
+        allElements.filter(el => el instanceof HTMLInputElement && el.name === name);
+
+    if (matchingElements.length === 1) {
+        return element.checked ? element.value : '';
+    }
+
+    return matchingElements
+        .filter(el => el instanceof HTMLInputElement && el.checked)
+        .map(el => el.value);
+}

--- a/src/lib/helpers/FormHelper.ts
+++ b/src/lib/helpers/FormHelper.ts
@@ -1,6 +1,7 @@
 import type { FormControlElement } from '$lib/models/formControlElement';
+import type { ValueType } from '$lib/models/formControl';
 
-export function setElementValue(element: FormControlElement, value: string | string[] | null) {
+export function setElementValue(element: FormControlElement, value: ValueType | null) {
     if (!value) return;
 
     if (element instanceof HTMLSelectElement) {
@@ -27,7 +28,7 @@ export function setElementValue(element: FormControlElement, value: string | str
     }
 }
 
-export function getElementValue(element: FormControlElement, allElements: FormControlElement[] = []): string | string[] {
+export function getElementValue(element: FormControlElement, allElements: FormControlElement[] = []): ValueType {
     if (element instanceof HTMLSelectElement) {
         if (element.multiple) {
             return [...element.selectedOptions].map((option) => option.value);
@@ -44,7 +45,7 @@ export function getElementValue(element: FormControlElement, allElements: FormCo
 }
 
 
-function getCheckboxValue(element: HTMLInputElement, allElements: FormControlElement[]): string | string[] {
+function getCheckboxValue(element: HTMLInputElement, allElements: FormControlElement[]): ValueType {
     const name = element.name;
     const matchingElements =
         allElements.filter(el => el instanceof HTMLInputElement && el.name === name);

--- a/src/lib/helpers/FormHelper.ts
+++ b/src/lib/helpers/FormHelper.ts
@@ -51,7 +51,7 @@ function getCheckboxValue(element: HTMLInputElement, allElements: FormControlEle
         allElements.filter(el => el instanceof HTMLInputElement && el.name === name);
 
     if (matchingElements.length === 1) {
-        return element.checked ? element.value : '';
+        return element.checked ? element.value || 'checked' : '';
     }
 
     return matchingElements

--- a/src/lib/models/form.ts
+++ b/src/lib/models/form.ts
@@ -72,33 +72,20 @@ export class Form<SKeys extends keyof any, MKeys extends keyof any> {
   /** @internal Add a form conrol to the Form */
   _addControl<T extends ValueType>(
     name: string,
-    initial: T | undefined,
+    initial: T,
     multiple: boolean,
     validators: Validator<T>[] = [],
     elements: FormControlElement[] = [],
     errorMap: ErrorMap = {}
   ) {
-    if (multiple) {
-      (this as any)[name] = new FormControl<string>({
-        value: initial as string || '',
-        multiple: multiple,
-        validators: validators as Validator<string>[],
+      (this as any)[name] = new FormControl<T>({
+        value: initial,
+        multiple: true,
+        validators: validators,
         elements: elements,
         errorMap: errorMap,
         formRef: () => this,
       });
-    } else {
-      (this as any)[name] = new FormControl<string[]>({
-        value: initial as string[] || [],
-        multiple: multiple,
-        validators: validators as Validator<string[]>[],
-        elements: elements,
-        errorMap: errorMap,
-        formRef: () => this,
-      });
-    }
-    const value = initial || (multiple ? [] : "");
-
   }
 
   private forEachControl(

--- a/src/lib/models/form.ts
+++ b/src/lib/models/form.ts
@@ -1,4 +1,4 @@
-import { FormControl } from "./formControl";
+import { FormControl, type ValueType } from './formControl';
 import type { FormControlElement } from "./formControlElement";
 import type { FormProperties } from "./formProperties";
 import type { ErrorMap, Validator } from "./validator";
@@ -67,8 +67,8 @@ export class Form<Keys extends keyof any> {
   /** @internal Add a form conrol to the Form */
   _addControl(
     name: string,
-    initial: string | string[] = "",
-    validators: Validator[] = [],
+    initial: ValueType = "",
+    validators: Validator<ValueType>[] = [],
     elements: FormControlElement[] = [],
     errorMap: ErrorMap = {}
   ) {

--- a/src/lib/models/form.ts
+++ b/src/lib/models/form.ts
@@ -67,7 +67,7 @@ export class Form<Keys extends keyof any> {
   /** @internal Add a form conrol to the Form */
   _addControl(
     name: string,
-    initial: string = "",
+    initial: string | string[] = "",
     validators: Validator[] = [],
     elements: FormControlElement[] = [],
     errorMap: ErrorMap = {}

--- a/src/lib/models/formControl.ts
+++ b/src/lib/models/formControl.ts
@@ -3,9 +3,11 @@ import type { FormControlElement } from "./formControlElement";
 import type { Validator, ValidationErrors, ErrorMap } from "./validator";
 import { setElementValue } from '$lib/helpers/FormHelper';
 
+export type ValueType = string | string[];
+
 /** A FormControl represents the state of a {@link FormControlElement} like (input, textarea...) */
 export class FormControl {
-  validators: Validator[];
+  validators: Validator<ValueType>[];
 
   /**
    * Returns an object containing possible validation errors
@@ -38,12 +40,12 @@ export class FormControl {
   _touched = false;
 
   /** The initial value of the FormControl. Defaults to `""` if not set via `useForm(params)`. */
-  initial: string | string[];
+  initial: ValueType;
 
   // TODO can we get the Form via Svelte context?
   private readonly formRef: () => Form<any>;
 
-  private _value: string | string[] = "";
+  private _value: ValueType = "";
 
   get value() {
     return this._value;
@@ -58,7 +60,7 @@ export class FormControl {
    *
    * See `change(value: String)` for doing both
    */
-  set value(value: string | string[]) {
+  set value(value: ValueType) {
     this._value = value;
     this.validate();
   }
@@ -72,8 +74,8 @@ export class FormControl {
   }
 
   constructor(formControl: {
-    value: string | string[];
-    validators: Validator[];
+    value: ValueType;
+    validators: Validator<ValueType>[];
     errorMap: ErrorMap;
     elements: FormControlElement[];
     formRef: () => Form<any>;
@@ -113,7 +115,7 @@ export class FormControl {
   }
 
   /** Change the value and the value of all HTML-Elements associated with this control */
-  change(value: any) {
+  change(value: ValueType) {
     this.value = value;
     this.elements.forEach((element) => setElementValue(element, value));
 
@@ -156,7 +158,7 @@ export class FormControl {
   }
 
   /** Reset the form control value to its initial value or `{ value }` and untouch it */
-  reset({ value }: { value?: string | null } = {}) {
+  reset({ value }: { value?: ValueType | null } = {}) {
     const resetValue = value == null ? this.initial : value;
     this.elements.forEach((element) => setElementValue(element, resetValue));
     this.value = resetValue;

--- a/src/lib/models/formControl.ts
+++ b/src/lib/models/formControl.ts
@@ -1,6 +1,7 @@
 import type { Form } from "./form";
 import type { FormControlElement } from "./formControlElement";
 import type { Validator, ValidationErrors, ErrorMap } from "./validator";
+import { setElementValue } from '$lib/helpers/FormHelper';
 
 /** A FormControl represents the state of a {@link FormControlElement} like (input, textarea...) */
 export class FormControl {
@@ -37,12 +38,12 @@ export class FormControl {
   _touched = false;
 
   /** The initial value of the FormControl. Defaults to `""` if not set via `useForm(params)`. */
-  initial: string;
+  initial: string | string[];
 
   // TODO can we get the Form via Svelte context?
   private readonly formRef: () => Form<any>;
 
-  private _value: string = "";
+  private _value: string | string[] = "";
 
   get value() {
     return this._value;
@@ -57,7 +58,7 @@ export class FormControl {
    *
    * See `change(value: String)` for doing both
    */
-  set value(value: string) {
+  set value(value: string | string[]) {
     this._value = value;
     this.validate();
   }
@@ -71,7 +72,7 @@ export class FormControl {
   }
 
   constructor(formControl: {
-    value: string;
+    value: string | string[];
     validators: Validator[];
     errorMap: ErrorMap;
     elements: FormControlElement[];
@@ -157,11 +158,12 @@ export class FormControl {
   /** Reset the form control value to its initial value or `{ value }` and untouch it */
   reset({ value }: { value?: string | null } = {}) {
     const resetValue = value == null ? this.initial : value;
-    this.elements.forEach((element) => (element.value = resetValue));
+    this.elements.forEach((element) => setElementValue(element, resetValue));
     this.value = resetValue;
     this.touched = false;
 
     // Updating the $form
     this.formRef()["_notifyListeners"]();
   }
+
 }

--- a/src/lib/models/formControl.ts
+++ b/src/lib/models/formControl.ts
@@ -7,7 +7,7 @@ export type ValueType = string | string[];
 
 /** A FormControl represents the state of a {@link FormControlElement} like (input, textarea...) */
 export class FormControl<T extends ValueType> {
-  validators: Validator<any>[];
+  validators: Validator<T>[];
 
   /**
    * Returns an object containing possible validation errors

--- a/src/lib/models/formControl.ts
+++ b/src/lib/models/formControl.ts
@@ -115,7 +115,7 @@ export class FormControl {
   /** Change the value and the value of all HTML-Elements associated with this control */
   change(value: any) {
     this.value = value;
-    this.elements.forEach((element) => (element.value = value));
+    this.elements.forEach((element) => setElementValue(element, value));
 
     // Update the $form
     this.formRef()["_notifyListeners"]();

--- a/src/lib/models/formProperties.ts
+++ b/src/lib/models/formProperties.ts
@@ -3,7 +3,7 @@ import type { ErrorMap, Validator } from "./validator";
 export type FormProperties = {
   [key: string]: {
     /** Initial value of the form control */
-    initial?: string;
+    initial?: string | string[];
     /** The validators that will be checked when the input changes */
     validators?: Validator[];
     /**

--- a/src/lib/models/formProperties.ts
+++ b/src/lib/models/formProperties.ts
@@ -1,18 +1,27 @@
-import type { ErrorMap, Validator } from "./validator";
-import type { ValueType } from '$lib/models/formControl';
+import type { ErrorMap, Validator } from './validator';
 
 export type FormProperties = {
-  [key: string]: {
-    /** Initial value of the form control */
-    initial?: ValueType;
-    /** The validators that will be checked when the input changes */
-    validators?: Validator<ValueType>[];
-    /**
-     * The map through which validation errors will be mapped.
-     * You can either pass a string or a function returning a new error value
-     *
-     * **Think of it as a translation map. 😆**
-     */
-    errorMap?: ErrorMap;
-  };
+    [key: string]: SingleValueFormProperty | MultiValueFormProperty;
 };
+
+export type SingleValueFormProperty = {
+    initial?: string;
+    validators?: Validator<string>[];
+    multiple?: false | undefined;
+    errorMap?: ErrorMap;
+}
+
+export type MultiValueFormProperty = {
+    initial?: string[];
+    validators?: Validator<string[]>[];
+    multiple: true;
+    errorMap?: ErrorMap;
+}
+
+export type SingleValueKeys<T extends FormProperties> = {
+    [K in keyof T]: T[K] extends SingleValueFormProperty ? K : never;
+}[keyof T];
+
+export type MultipleValueKeys<T extends FormProperties> = {
+    [K in keyof T]: T[K] extends MultiValueFormProperty ? K : never;
+}[keyof T];

--- a/src/lib/models/formProperties.ts
+++ b/src/lib/models/formProperties.ts
@@ -1,11 +1,12 @@
 import type { ErrorMap, Validator } from "./validator";
+import type { ValueType } from '$lib/models/formControl';
 
 export type FormProperties = {
   [key: string]: {
     /** Initial value of the form control */
-    initial?: string | string[];
+    initial?: ValueType;
     /** The validators that will be checked when the input changes */
-    validators?: Validator[];
+    validators?: Validator<ValueType>[];
     /**
      * The map through which validation errors will be mapped.
      * You can either pass a string or a function returning a new error value

--- a/src/lib/models/validator.ts
+++ b/src/lib/models/validator.ts
@@ -8,7 +8,7 @@ import type { FormControl } from "./formControl";
  */
 export type Validator = (
   /** The value of the control. */
-  value: string,
+  value: string | string[],
   /** The containing form. */
   form: Form<any> & FormControlsUnspecified,
   /** The control this validator was assigned to. */

--- a/src/lib/models/validator.ts
+++ b/src/lib/models/validator.ts
@@ -1,14 +1,14 @@
 import type { Form, FormControlsUnspecified } from "./form";
-import type { FormControl } from "./formControl";
+import type { FormControl, ValueType } from './formControl';
 
 /**
  * A function that depending on the control's validity either returns:
  * - `null | undefined` when **valid**
  * - {@link ValidationErrors} when **invalid**.
  */
-export type Validator = (
+export type Validator<T extends ValueType> = (
   /** The value of the control. */
-  value: string | string[],
+  value: T,
   /** The containing form. */
   form: Form<any> & FormControlsUnspecified,
   /** The control this validator was assigned to. */

--- a/src/lib/models/validator.ts
+++ b/src/lib/models/validator.ts
@@ -10,9 +10,9 @@ export type Validator<T extends ValueType> = (
   /** The value of the control. */
   value: T,
   /** The containing form. */
-  form: Form<any> & FormControlsUnspecified,
+  form: Form<any, any> & FormControlsUnspecified,
   /** The control this validator was assigned to. */
-  control: FormControl
+  control: FormControl<T>
 ) => ValidationErrors | (null | undefined);
 
 /** An object that contains errors thrown by the validator. */

--- a/src/lib/stores/formReferences.ts
+++ b/src/lib/stores/formReferences.ts
@@ -2,7 +2,7 @@ import { writable } from "svelte/store";
 import type { Form, FormControlsUnspecified } from "../models/form";
 
 export type FormReference = {
-  form: Form<any> & FormControlsUnspecified;
+  form: Form<any, any> & FormControlsUnspecified;
   node: HTMLFormElement;
   notifyListeners: Function;
 };

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,22 +1,22 @@
 import type { Validator } from "./models/validator";
 
-export const required: Validator = (value) => {
+export const required: Validator<string> = (value) => {
   return value.trim() ? null : { required: "Required" };
 };
 
-export function maxLength(length: number): Validator {
+export function maxLength(length: number): Validator<string> {
   return (value) => {
     if (value.trim().length > length) return { maxLength: length };
   };
 }
 
-export function minLength(length: number): Validator {
+export function minLength(length: number): Validator<string> {
   return (value) => {
     if (value.trim().length < length) return { minLength: length };
   };
 }
 
-export const email: Validator = (value) => {
+export const email: Validator<string> = (value) => {
   if (
     /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/.test(
       value
@@ -27,7 +27,7 @@ export const email: Validator = (value) => {
   return { email: {} };
 };
 
-export const url: Validator = (value) => {
+export const url: Validator<string> = (value) => {
   // https://stackoverflow.com/a/5717133/13475809
   var pattern = new RegExp(
     "^(https?:\\/\\/)?" + // protocol
@@ -44,14 +44,14 @@ export const url: Validator = (value) => {
   return { url: "URL is not valid" };
 };
 
-export const number: Validator = (value) => {
+export const number: Validator<string> = (value) => {
   if (/^[0-9]+$/.test(value)) {
     return null;
   }
   return { number: {} };
 };
 
-export function pattern(regExp: string | RegExp): Validator {
+export function pattern(regExp: string | RegExp): Validator<string> {
   const r = typeof regExp === "string" ? new RegExp(regExp) : regExp;
   return (value) => (r.test(value) ? null : { pattern: "Pattern error" });
 }

--- a/src/lib/validatorsAction.ts
+++ b/src/lib/validatorsAction.ts
@@ -1,6 +1,6 @@
 import { tick } from "svelte";
 import { get } from "svelte/store";
-import { FormControl } from "./models/formControl";
+import { FormControl, type ValueType } from './models/formControl';
 import type { FormControlElement } from "./models/formControlElement";
 import type { Validator } from "./models/validator";
 import { formReferences, type FormReference } from "./stores/formReferences";
@@ -14,7 +14,7 @@ import { formReferences, type FormReference } from "./stores/formReferences";
  */
 export function validators(
   element: FormControlElement,
-  validators: Validator[]
+  validators: Validator<ValueType>[]
 ) {
   let formControl: FormControl | undefined;
   let formReference: FormReference | undefined;
@@ -56,7 +56,7 @@ export function validators(
     formReference.notifyListeners();
   }
 
-  function updateValidators(updatedValidators: Validator[]) {
+  function updateValidators(updatedValidators: Validator<ValueType>[]) {
     if (!formControl || !formReference) return;
 
     // Get the static validators (The validators set via useForm({...}))

--- a/src/lib/validatorsAction.ts
+++ b/src/lib/validatorsAction.ts
@@ -1,6 +1,6 @@
 import { tick } from "svelte";
 import { get } from "svelte/store";
-import { FormControl, type ValueType } from './models/formControl';
+import { FormControl } from './models/formControl';
 import type { FormControlElement } from "./models/formControlElement";
 import type { Validator } from "./models/validator";
 import { formReferences, type FormReference } from "./stores/formReferences";
@@ -12,11 +12,11 @@ import { formReferences, type FormReference } from "./stores/formReferences";
  * <input name="nameOfInput" use:validators={[required, minLength(5), maxLength(20)]} />
  * ```
  */
-export function validators<T extends ValueType>(
+export function validators(
   element: FormControlElement,
-  validators: Validator<T>[]
+  validators: Validator<any>[]
 ) {
-  let formControl: FormControl<T> | undefined;
+  let formControl: FormControl<string | string[]> | undefined;
   let formReference: FormReference | undefined;
 
   setupValidators();
@@ -45,18 +45,18 @@ export function validators<T extends ValueType>(
     formReference = possibleFormReference;
 
     let possibleFormControl = formReference.form[element.name];
-    if (!(possibleFormControl instanceof FormControl))
+    if (!(possibleFormControl instanceof FormControl<any>))
       throw new ValidatorsActionError(
         `Form Control [${element.name}] doesn't exist.`
       );
 
-    formControl = possibleFormControl;
+    formControl = possibleFormControl as FormControl<any>;
     formControl.validators.push(...validators);
     formControl.validate();
     formReference.notifyListeners();
   }
 
-  function updateValidators(updatedValidators: Validator<ValueType>[]) {
+  function updateValidators(updatedValidators: Validator<any>[]) {
     if (!formControl || !formReference) return;
 
     // Get the static validators (The validators set via useForm({...}))

--- a/src/lib/validatorsAction.ts
+++ b/src/lib/validatorsAction.ts
@@ -12,11 +12,11 @@ import { formReferences, type FormReference } from "./stores/formReferences";
  * <input name="nameOfInput" use:validators={[required, minLength(5), maxLength(20)]} />
  * ```
  */
-export function validators(
+export function validators<T extends ValueType>(
   element: FormControlElement,
-  validators: Validator<ValueType>[]
+  validators: Validator<T>[]
 ) {
-  let formControl: FormControl | undefined;
+  let formControl: FormControl<T> | undefined;
   let formReference: FormReference | undefined;
 
   setupValidators();


### PR DESCRIPTION
Checkboxes with the same name and Multiple selects are currently not supported. This adds support for both by setting the value to an array of strings if it detects it is a multiple element. 

This also changes to use the value of the checkbox instead of "checked" when setting the value.