### PR TITLE
Update number validator, add digits validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ And thus it won't be validated or observed for changes.
 - `minLength(n)`
 - `maxLength(n)`
 - `number`
+- `digits`
 - `email`
 - `emailWithTld`
 - `url`

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -15,6 +15,7 @@ export {
   email,
   emailWithTld,
   url,
+  digits,
   number,
   pattern,
 } from "./validators";

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -59,8 +59,15 @@ export const url: Validator = (value) => {
   return { url: "URL is not valid" };
 };
 
-export const number: Validator = (value) => {
+export const digits: Validator = (value) => {
   if (/^[0-9]+$/.test(value)) {
+    return null;
+  }
+  return { digits: {} };
+};
+
+export const number: Validator = (value) => {
+  if (/^-?[0-9]+(\.[0-9]+)?$/.test(value)) {
     return null;
   }
   return { number: {} };

--- a/src/routes/examples/digits-validator/+page.svelte
+++ b/src/routes/examples/digits-validator/+page.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { useForm, validators, digits } from "$lib";
+
+  const form = useForm();
+</script>
+
+<form use:form>
+  <input
+    id="testDigitsField"
+    name="testDigitsField"
+    use:validators={[digits]}
+  />
+  <input
+    type="checkbox"
+    id="isValid"
+    checked={!!$form.testDigitsField?.errors.digits}
+  />
+</form>

--- a/src/routes/examples/number-validator/+page.svelte
+++ b/src/routes/examples/number-validator/+page.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { useForm, validators, number } from "$lib";
+
+  const form = useForm();
+</script>
+
+<form use:form>
+  <input
+    id="testNumberField"
+    name="testNumberField"
+    use:validators={[number]}
+  />
+  <input
+    type="checkbox"
+    id="isValid"
+    checked={!!$form.testNumberField?.errors.number}
+  />
+</form>

--- a/tests/digits-validator.spec.ts
+++ b/tests/digits-validator.spec.ts
@@ -1,0 +1,35 @@
+import test, { expect } from "@playwright/test";
+
+const validDigits = ["0", "1234567890", "01"];
+
+test(`Verify valid digits are marked as valid by the digits validator`, async ({
+  page,
+}) => {
+  for (const digit of validDigits) {
+    await page.goto("examples/digits-validator");
+
+    const input = page.locator("#testDigitsField");
+    const isRequiredErrorTriggered = page.locator("#isValid");
+
+    await input.clear();
+    await input.type(digit);
+    await expect(isRequiredErrorTriggered).not.toBeChecked();
+  }
+});
+
+const invalidDigits = ["-0", "1.9", "one", "true"];
+
+test(`Verify invalid digits are marked as invalid by the digits validator`, async ({
+  page,
+}) => {
+  for (const digit of invalidDigits) {
+    await page.goto("examples/digits-validator");
+
+    const input = page.locator("#testDigitsField");
+    const isRequiredErrorTriggered = page.locator("#isValid");
+
+    await input.clear();
+    await input.type(digit);
+    await expect(isRequiredErrorTriggered).toBeChecked();
+  }
+});

--- a/tests/number-validator.spec.ts
+++ b/tests/number-validator.spec.ts
@@ -1,0 +1,43 @@
+import test, { expect } from "@playwright/test";
+
+const validNumbers = ["0", "1234567890", "01", "-11", "-1.09", "34.56"];
+
+test(`Verify valid numbers are marked as valid by the numbers validator`, async ({
+  page,
+}) => {
+  for (const num of validNumbers) {
+    await page.goto("examples/number-validator");
+
+    page.on("console", (msg) => {
+      console.log(msg);
+    });
+
+    const input = page.locator("#testNumberField");
+    const isRequiredErrorTriggered = page.locator("#isValid");
+
+    await input.clear();
+    await input.type(num);
+    await expect(isRequiredErrorTriggered).not.toBeChecked();
+  }
+});
+
+const invalidNumbers = ["1-0", "2-", "3.4.5", "one", "true"];
+
+test(`Verify invalid numbers are marked as invalid by the numbers validator`, async ({
+  page,
+}) => {
+  for (const num of invalidNumbers) {
+    await page.goto("examples/number-validator");
+
+    page.on("console", (msg) => {
+      console.log(msg);
+    });
+
+    const input = page.locator("#testNumberField");
+    const isRequiredErrorTriggered = page.locator("#isValid");
+
+    await input.clear();
+    await input.type(num);
+    await expect(isRequiredErrorTriggered).toBeChecked();
+  }
+});


### PR DESCRIPTION
Updating as discussed in https://github.com/noahsalvi/svelte-use-form/issues/66

Note, I realised that `integer` would have been a poor name too, as it wouldn't support negative integers with the current behaviour. Instead I went with `digits`.

I noticed most validators are singular, but I felt `digit` implied it would accept a singular digit, rather than multiple and so this was clearer.

The new `number` validator implementation accepts negative or positive, decimal or int. I haven't added anything fancy on top of that.

I did add a test spec for both `number` and `digits`